### PR TITLE
Install APCu stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - printf "\n" | pecl install imagick
   - pecl install stats
   - sudo apt-get install libgearman-dev && pecl install gearman-1.0.3
-  - sh -c "if [ `php-config --vernum` -ge 50500 ]; then printf "yes\n" | pecl install apcu-beta; fi"
+  - sh -c "if [ `php-config --vernum` -ge 50500 ]; then printf "yes\n" | pecl install apcu; fi"
   - phpenv config-add tests/travis/php.ini
   - phpenv config-add tests/travis/php-$TRAVIS_PHP_VERSION.ini
   - npm install -g autoprefixer

--- a/library/CM/Service/MongoDb.php
+++ b/library/CM/Service/MongoDb.php
@@ -31,7 +31,7 @@ class CM_Service_MongoDb extends CM_Service_ManagerAware {
      */
     public function insert($collection, array $object) {
         CM_Debug::getInstance()->incStats('mongo', "insert to {$collection}");
-        $ref = &$object;
+        $ref = $object;
         return $this->_getCollection($collection)->insert($ref);
     }
 
@@ -202,7 +202,7 @@ class CM_Service_MongoDb extends CM_Service_ManagerAware {
     /**
      * @return MongoClient
      */
-    public function _getClient() {
+    protected function _getClient() {
         if (null === $this->_client) {
             $this->_client = new MongoClient($this->_config['server'], $this->_config['options']);
         }


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.
